### PR TITLE
Route OAuth callback through the vice-operator relay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cyverse-de/vice-proxy
 go 1.25
 
 require (
-	github.com/cyverse-de/go-mod/viceauth v0.0.0-20260514164934-ce1628b2909f
+	github.com/cyverse-de/go-mod/viceauth v1.0.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cyverse-de/vice-proxy
 go 1.25
 
 require (
+	github.com/cyverse-de/go-mod/viceauth v0.0.0-20260514164934-ce1628b2909f
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cyverse-de/go-mod/viceauth v0.0.0-20260514164934-ce1628b2909f h1:vB6QdLFXYouqfvYO1U64NDBgrzbonlt5+wH4HLrNYWQ=
+github.com/cyverse-de/go-mod/viceauth v0.0.0-20260514164934-ce1628b2909f/go.mod h1:58UZ7WOFEAA3gy4Allc9NzVviiK10c4/2fwZDuQVXVo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cyverse-de/go-mod/viceauth v0.0.0-20260514164934-ce1628b2909f h1:vB6QdLFXYouqfvYO1U64NDBgrzbonlt5+wH4HLrNYWQ=
-github.com/cyverse-de/go-mod/viceauth v0.0.0-20260514164934-ce1628b2909f/go.mod h1:58UZ7WOFEAA3gy4Allc9NzVviiK10c4/2fwZDuQVXVo=
+github.com/cyverse-de/go-mod/viceauth v1.0.0 h1:k5lCiBi7Lfa4eHZfkD1Msnez5kcAgoyUELPVSSr61H4=
+github.com/cyverse-de/go-mod/viceauth v1.0.0/go.mod h1:58UZ7WOFEAA3gy4Allc9NzVviiK10c4/2fwZDuQVXVo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ type VICEProxy struct {
 	keycloakRealm        string                // The realm to use when checking for Keycloak authentication.
 	keycloakClientID     string                // The OIDC client ID for Keycloak.
 	keycloakClientSecret string                // The OIDC client secret for Keycloak.
-	frontendURL          string                // The redirect URL.
+	frontendURL          string                // The app's public base URL; used to build the post-login browser redirect, not the OAuth redirect_uri (see operatorCallbackURL).
 	backendURL           string                // The backend URL to forward to.
 	wsbackendURL         string                // The websocket URL to forward requests to.
 	resourceName         string                // The UUID of the analysis.
@@ -326,10 +326,21 @@ func (c *VICEProxy) HandleAuthorizationCode(w http.ResponseWriter, r *http.Reque
 	log.Debug("validating an authorization code received from Keycloak")
 	var err error
 
+	// Surface a Keycloak-side error (e.g. the user denied consent) directly.
+	// Such a response carries no code or state, so without this check the flow
+	// would fall through to the state check and report a confusing "no state
+	// found". Only the bounded RFC 6749 error code is echoed to the browser;
+	// the full description is logged server-side.
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		log.Errorf("Keycloak returned an error: %s: %s", errParam, r.URL.Query().Get("error_description"))
+		http.Error(w, fmt.Sprintf("authentication failed: %s", errParam), http.StatusUnauthorized)
+		return
+	}
+
 	// Validate the state query parameter to mitigate CSRF attacks. The state is
 	// an HMAC-signed blob produced by RequireKeycloakAuth and relayed back
 	// untouched by the vice-operator. Only its StateID is checked against the
-	// cookie here; the Origin field was the operator's concern.
+	// cookie here; the Origin field is the operator's concern.
 	rawState := r.URL.Query().Get("state")
 	if rawState == "" {
 		err = errors.New("no state found in query string")

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cyverse-de/go-mod/viceauth"
 	"github.com/fsnotify/fsnotify"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -74,6 +75,8 @@ type VICEProxy struct {
 	activeSessions       sync.Map              // Tracks valid Keycloak session IDs; entries removed on logout.
 	allowedUsers         sync.Map              // In-memory set of usernames allowed to access this analysis.
 	adminEntitlements    []string              // Entitlement-claim values that grant admin access regardless of allowedUsers.
+	operatorCallbackURL  string                // Static redirect_uri registered in Keycloak; the vice-operator relays the auth code from here back to this app.
+	stateCodec           *viceauth.Codec       // Signs and verifies the OAuth state parameter that round-trips through the operator relay.
 }
 
 // loadAllowedUsers reads the allowed-users file and populates the in-memory set.
@@ -323,12 +326,22 @@ func (c *VICEProxy) HandleAuthorizationCode(w http.ResponseWriter, r *http.Reque
 	log.Debug("validating an authorization code received from Keycloak")
 	var err error
 
-	// Validate the state query parameter to mitigate CSRF attacks.
-	actualState := r.URL.Query().Get("state")
-	if actualState == "" {
+	// Validate the state query parameter to mitigate CSRF attacks. The state is
+	// an HMAC-signed blob produced by RequireKeycloakAuth and relayed back
+	// untouched by the vice-operator. Only its StateID is checked against the
+	// cookie here; the Origin field was the operator's concern.
+	rawState := r.URL.Query().Get("state")
+	if rawState == "" {
 		err = errors.New("no state found in query string")
 		log.Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	stateClaims, err := c.stateCodec.Decode(rawState)
+	if err != nil {
+		err = errors.Wrap(err, "failed to decode the OAuth state")
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	session, err := c.sessionStore.Get(r, stateSessionName)
@@ -345,7 +358,7 @@ func (c *VICEProxy) HandleAuthorizationCode(w http.ResponseWriter, r *http.Reque
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if expectedState != actualState {
+	if expectedState != stateClaims.StateID {
 		err = errors.New("expected state ID does not equal actual state ID")
 		log.Error(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -370,7 +383,10 @@ func (c *VICEProxy) HandleAuthorizationCode(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Build the redirect URL.
+	// Build the clean post-login redirect URL — where the browser is sent once
+	// the token is obtained. The browser is already back on this app's domain
+	// at this point, so it is derived from frontendURL plus the original path,
+	// with the OAuth round-trip parameters stripped.
 	redirectURL, err := url.Parse(c.frontendURL)
 	if err != nil {
 		err = errors.Wrap(err, "failed to parse the frontend URL")
@@ -386,11 +402,13 @@ func (c *VICEProxy) HandleAuthorizationCode(w http.ResponseWriter, r *http.Reque
 	redirectURL.RawQuery = params.Encode()
 	redirectURL.Path = r.URL.Path
 
-	// Build the form parameters.
+	// Build the form parameters. The redirect_uri here must byte-match the one
+	// sent to Keycloak's auth endpoint (the operator callback URL), not this
+	// app's URL — OAuth requires the two to be identical.
 	formParams := url.Values{}
 	formParams.Set("grant_type", "authorization_code")
 	formParams.Set("code", code)
-	formParams.Set("redirect_uri", redirectURL.String())
+	formParams.Set("redirect_uri", c.operatorCallbackURL)
 	formParams.Set("client_id", c.keycloakClientID)
 	formParams.Set("client_secret", c.keycloakClientSecret)
 
@@ -527,15 +545,29 @@ func (c *VICEProxy) RequireKeycloakAuth(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Build the redirect URL.
-	redirectURL, err := url.Parse(c.frontendURL)
+	// Build the origin URL: the app URL the browser should be returned to once
+	// the vice-operator relays the authorization code back. It travels (signed)
+	// in the state parameter rather than as redirect_uri, because Keycloak
+	// cannot wildcard-match per-app VICE subdomains — only the operator's fixed
+	// callback URL is registered as a valid redirect_uri.
+	originURL, err := url.Parse(c.frontendURL)
 	if err != nil {
 		err = errors.Wrapf(err, "failed to parse the frontend URL: %s", c.frontendURL)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	redirectURL.Path = r.URL.Path
-	redirectURL.RawQuery = r.URL.RawQuery
+	originURL.Path = r.URL.Path
+	originURL.RawQuery = r.URL.RawQuery
+
+	state, err := c.stateCodec.Encode(viceauth.StateClaims{
+		StateID: stateID.String(),
+		Origin:  originURL.String(),
+	})
+	if err != nil {
+		err = errors.Wrap(err, "failed to encode the OAuth state")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	// Build the login URL and set the query parameters.
 	loginURL, err := c.KeycloakURL("auth")
@@ -546,8 +578,8 @@ func (c *VICEProxy) RequireKeycloakAuth(w http.ResponseWriter, r *http.Request) 
 	}
 	params := loginURL.Query()
 	params.Set("client_id", c.keycloakClientID)
-	params.Set("state", stateID.String())
-	params.Set("redirect_uri", redirectURL.String())
+	params.Set("state", state)
+	params.Set("redirect_uri", c.operatorCallbackURL)
 	params.Set("scope", "openid")
 	params.Set("response_type", "code")
 	loginURL.RawQuery = params.Encode()
@@ -937,6 +969,12 @@ func main() {
 	disableAuth := strings.EqualFold(os.Getenv("DISABLE_AUTH"), "true")
 	adminEntitlements := parseAdminEntitlements(os.Getenv("ADMIN_ENTITLEMENTS"))
 
+	// operatorCallbackURL is the single static redirect_uri registered in
+	// Keycloak for the vice-users client; stateHMACSecret signs the OAuth state
+	// blob so the vice-operator relay can trust the embedded app URL.
+	operatorCallbackURL := os.Getenv("OPERATOR_CALLBACK_URL")
+	stateHMACSecret := os.Getenv("STATE_HMAC_SECRET")
+
 	// Validate required Keycloak env vars when auth is enabled to fail fast
 	// rather than producing confusing URL construction errors at login time.
 	if !disableAuth {
@@ -952,6 +990,12 @@ func main() {
 		}
 		if keycloakClientSecret == "" {
 			missing = append(missing, "KEYCLOAK_CLIENT_SECRET")
+		}
+		if operatorCallbackURL == "" {
+			missing = append(missing, "OPERATOR_CALLBACK_URL")
+		}
+		if stateHMACSecret == "" {
+			missing = append(missing, "STATE_HMAC_SECRET")
 		}
 		if len(missing) > 0 {
 			log.Fatalf("auth is enabled but required env vars are missing: %s", strings.Join(missing, ", "))
@@ -1041,6 +1085,12 @@ func main() {
 		Path:     "/",
 		MaxAge:   *maxAge,
 		HttpOnly: true,
+		// The login flow returns the browser to this app via a cross-site
+		// top-level redirect (Keycloak, then the vice-operator relay), so the
+		// state cookie must survive a SameSite=Lax navigation. Secure is gated
+		// on the deployment actually serving HTTPS.
+		SameSite: http.SameSiteLaxMode,
+		Secure:   strings.HasPrefix(frontendURL, "https://"),
 	}
 
 	// Decode the timeout duration for back-channel requests to the identity provider.
@@ -1089,6 +1139,8 @@ func main() {
 		ssoClient:            *client,
 		disableAuth:          disableAuth,
 		adminEntitlements:    adminEntitlements,
+		operatorCallbackURL:  operatorCallbackURL,
+		stateCodec:           viceauth.NewCodec([]byte(stateHMACSecret)),
 	}
 
 	// Load the initial allowed-users list from the permissions ConfigMap mount.


### PR DESCRIPTION
## Summary
- vice-proxy no longer sends its own per-app subdomain as the Keycloak `redirect_uri` — Keycloak only honors `*` as a *trailing* wildcard, so `https://*.cyverse.run:4343/*` can never match a real VICE subdomain (this is the "invalid parameter: redirect_uri" error seen in QA).
- It now sends the **vice-operator's fixed callback URL** as `redirect_uri` and carries the original app URL inside an HMAC-signed `state` blob (new `github.com/cyverse-de/go-mod/viceauth` codec).
- The operator relays the auth code back to this app's subdomain, where the state cookie is still present and the code is exchanged as before. The operator never does a token exchange and never holds the client secret.

## Changes
- `RequireKeycloakAuth`: encodes signed state (`StateID` + `Origin`); uses `OPERATOR_CALLBACK_URL` as `redirect_uri`.
- `HandleAuthorizationCode`: decodes/verifies state, compares `StateID` against the cookie; token-exchange `redirect_uri` now byte-matches the operator callback URL.
- State-session cookie gains `SameSite=Lax` + `Secure` (gated on an HTTPS frontend) to survive the extra cross-site redirect hop.
- New required env vars when auth is enabled: `OPERATOR_CALLBACK_URL`, `STATE_HMAC_SECRET` (delivered via the cluster-config Secret).

## Dependencies
- Depends on cyverse-de/go-mod#11 (the `viceauth` module) — currently pinned to a pseudo-version of that branch; will be bumped to `viceauth/v1.0.0` once it merges.
- Companion PR in `app-exposer` adds the operator-side `/auth/callback` relay handler and the two new cluster-config keys.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt`
- [ ] Register the QA operator's `/auth/callback` URL in Keycloak
- [ ] End-to-end in QA: launch a VICE app, confirm redirect to Keycloak carries the operator callback URL, login bounces operator → app subdomain, session established
- [ ] Negative: hand-crafted `state` with off-domain `Origin` is rejected by the operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
